### PR TITLE
feat: refactor card component

### DIFF
--- a/src/components/Card/__tests__/testCard.tsx
+++ b/src/components/Card/__tests__/testCard.tsx
@@ -12,7 +12,7 @@ jest.mock('react-router-dom', () => ({
 
 describe('Card', () => {
     it('should render card with single column', () => {
-        var columns = [{key: 'columnKey', value: 'columnValue'}];
+        const columns = [{key: 'columnKey', value: 'columnValue'}];
         render(<Card columns={columns} />);
 
         expect(screen.getByText('columnKey')).toBeInTheDocument();
@@ -20,7 +20,7 @@ describe('Card', () => {
     });
 
     it('should render card with multiple columns', () => {
-        var columns = [
+        const columns = [
             {key: 'columnKey1', value: 'columnValue1'},
             {key: 'columnKey2', value: 'columnValue2'},
             {key: 'columnKey3', value: 'columnValue3'},
@@ -38,10 +38,10 @@ describe('Card', () => {
     });
 
     it('should navigate when card is clicked and navigation is enabled', () => {
-        const navProps = {
+        const navProps: Teams = {
             id: '1',
             name: 'Team 1',
-        } as Teams;
+        };
         render(
             <Card
                 columns={[{key: 'columnKey', value: 'columnValue'}]}
@@ -61,5 +61,14 @@ describe('Card', () => {
         fireEvent.click(screen.getByText('columnKey'));
 
         expect(mockUseNavigate).not.toHaveBeenCalled();
+    });
+
+    it('should call preventDefault when card is clicked', () => {
+        const columns = [{key: 'columnKey', value: 'columnValue'}];
+        render(<Card columns={columns} />);
+
+        const preventDefault = fireEvent.click(screen.getByText('columnKey'));
+
+        expect(preventDefault).toBe(false);
     });
 });

--- a/src/components/Card/index.tsx
+++ b/src/components/Card/index.tsx
@@ -27,13 +27,14 @@ const Card = ({
         <Container
             data-testid={`cardContainer-${id}`}
             hasNavigation={hasNavigation}
-            onClick={(e: Event) => {
+            onClick={(e: React.MouseEvent) => {
+                e.preventDefault();
+
                 if (hasNavigation) {
                     navigate(url, {
                         state: navigationProps,
                     });
                 }
-                e.preventDefault();
             }}
         >
             {columns.map(({key: columnKey, value}) => (


### PR DESCRIPTION
- convert the `var`s into `const`s in order to have a better predictability
- remove the typecasting, because if you use it incorrectly, you may introduce type-related bugs that TypeScript cannot catch
- move the `e.preventDefault();` to the top of the function, because it can introduce unexpected behavior duo to the navigation function call.
- create a new test to check if we stop the default behavior is prevented, which might be useful when the card is used within a form or when there's a need to stop the default click behavior