### PR TITLE
feat: refactor list component

### DIFF
--- a/src/components/List/__tests__/testList.tsx
+++ b/src/components/List/__tests__/testList.tsx
@@ -1,11 +1,18 @@
 import React from 'react';
-import {render, screen} from '@testing-library/react';
+import {render} from '@testing-library/react';
+import Card from '../../Card';
+import {Spinner} from '../../Spinner';
 import List from '..';
 
 jest.mock('react-router-dom', () => ({
     ...(jest.requireActual('react-router-dom') as any),
     useNavigate: () => jest.fn(),
 }));
+jest.mock('../../Card');
+jest.mock('../../Spinner');
+
+const CardMock = Card as jest.Mock;
+const SpinnerMock = Spinner as jest.Mock;
 
 describe('List', () => {
     it('should render spinner and not render items when it is loading', () => {
@@ -22,52 +29,81 @@ describe('List', () => {
         ];
         render(<List isLoading items={items} />);
 
-        expect(screen.getByTestId('spinner')).toBeInTheDocument();
-        expect(screen.queryByTestId('cardContainer')).not.toBeInTheDocument();
+        expect(SpinnerMock).toHaveBeenCalledTimes(1);
+        expect(CardMock).toHaveBeenCalledTimes(0);
     });
 
     it('should not render spinner and render items when it is not loading', () => {
+        const itemOneColumns = [
+            {
+                key: 'columnKey1',
+                value: 'columnValue1',
+            },
+        ];
         const items = [
             {
                 id: '1',
-                columns: [
-                    {
-                        key: 'columnKey1',
-                        value: 'columnValue1',
-                    },
-                ],
+                columns: itemOneColumns,
             },
         ];
         render(<List isLoading={false} items={items} />);
 
-        expect(screen.queryByTestId('spinner')).not.toBeInTheDocument();
-        expect(screen.getByTestId('cardContainer-1')).toBeInTheDocument();
+        expect(SpinnerMock).toHaveBeenCalledTimes(0);
+        expect(CardMock).toHaveBeenCalledTimes(1);
+        expect(CardMock).toHaveBeenCalledWith(
+            expect.objectContaining({
+                id: '1',
+                columns: itemOneColumns,
+                navigationProps: undefined,
+                hasNavigation: true,
+                url: undefined,
+            }),
+            {}
+        );
     });
 
     it('should render multiple card when multiple items', () => {
-        const items = [
-            {
-                id: '1',
-                columns: [
-                    {
-                        key: 'columnKey1',
-                        value: 'columnValue1',
-                    },
-                ],
-            },
-            {
-                id: '2',
-                columns: [
-                    {
-                        key: 'columnKey2',
-                        value: 'columnValue2',
-                    },
-                ],
-            },
-        ];
+        const itemOne = {
+            id: '1',
+            columns: [
+                {
+                    key: 'columnKey1',
+                    value: 'columnValue1',
+                },
+            ],
+        };
+        const itemTwo = {
+            id: '2',
+            columns: [
+                {
+                    key: 'columnKey2',
+                    value: 'columnValue2',
+                },
+            ],
+        };
+        const items = [itemOne, itemTwo];
         render(<List isLoading={false} items={items} />);
 
-        expect(screen.getByTestId('cardContainer-1')).toBeInTheDocument();
-        expect(screen.getByTestId('cardContainer-2')).toBeInTheDocument();
+        expect(CardMock).toHaveBeenCalledTimes(2);
+        expect(CardMock.mock.calls[0]).toEqual([
+            {
+                id: itemOne.id,
+                columns: itemOne.columns,
+                navigationProps: undefined,
+                hasNavigation: true,
+                url: undefined,
+            },
+            {},
+        ]);
+        expect(CardMock.mock.calls[1]).toEqual([
+            {
+                id: '2',
+                columns: itemTwo.columns,
+                navigationProps: undefined,
+                hasNavigation: true,
+                url: undefined,
+            },
+            {},
+        ]);
     });
 });

--- a/src/components/List/index.tsx
+++ b/src/components/List/index.tsx
@@ -5,28 +5,28 @@ import {Spinner} from '../Spinner';
 import {Container} from './styles';
 
 interface Props {
-    items?: ListItem[];
+    items: ListItem[];
     hasNavigation?: boolean;
     isLoading: boolean;
 }
 
-const List = ({items, hasNavigation = true, isLoading}: Props) => {
+const List = ({items, hasNavigation = true, isLoading}: Props): JSX.Element => {
     return (
         <Container>
-            {isLoading && <Spinner />}
-            {!isLoading &&
-                items.map(({url, id, columns, navigationProps}, index) => {
-                    return (
-                        <Card
-                            key={`${id}-${index}`}
-                            id={id}
-                            columns={columns}
-                            navigationProps={navigationProps}
-                            hasNavigation={hasNavigation}
-                            url={url}
-                        />
-                    );
-                })}
+            {isLoading ? (
+                <Spinner />
+            ) : (
+                items.map(({url, id, columns, navigationProps}, index) => (
+                    <Card
+                        key={`${id}-${index}`}
+                        id={id}
+                        columns={columns}
+                        navigationProps={navigationProps}
+                        hasNavigation={hasNavigation}
+                        url={url}
+                    />
+                ))
+            )}
         </Container>
     );
 };


### PR DESCRIPTION
- add a return type for the component, to ensure better type safety
- make the `items` prop required. this might cause issues if `items` is not passed to the component, as `items.map()` would throw an error if `items` is `undefined`
- use conditional rendering to render the spinner or the items list, avoiding running the mapping function when `items` is empty or `isLoading` is `true`
- add components mock in the test file, it can avoid testing the internal behaviors of the components