### PR TITLE
feat: refactor teams page

### DIFF
--- a/src/pages/Teams.tsx
+++ b/src/pages/Teams.tsx
@@ -1,26 +1,9 @@
 import * as React from 'react';
-import {ListItem, Teams as TeamsList} from 'types';
+import {mapTeamsToListItems} from '../utils/teamUtils';
 import {useFetchTeams} from '../data/useFetchTeams';
 import Header from '../components/Header';
 import List from '../components/List';
 import {Container} from '../components/GlobalComponents';
-
-export const MapT = (teams: TeamsList[]) => {
-    return teams?.map(team => {
-        var columns = [
-            {
-                key: 'Name',
-                value: team.name,
-            },
-        ];
-        return {
-            id: team.id,
-            url: `/team/${team.id}`,
-            columns,
-            navigationProps: team,
-        } as ListItem;
-    });
-};
 
 const Teams = () => {
     const {data, isLoading} = useFetchTeams();
@@ -28,7 +11,7 @@ const Teams = () => {
     return (
         <Container>
             <Header title="Teams" showBackButton={false} />
-            <List items={MapT(data)} isLoading={isLoading} />
+            <List items={mapTeamsToListItems(data)} isLoading={isLoading} />
         </Container>
     );
 };

--- a/src/pages/__tests__/testTeams.tsx
+++ b/src/pages/__tests__/testTeams.tsx
@@ -1,9 +1,10 @@
 import * as React from 'react';
 import {render} from '@testing-library/react';
-import Teams, {MapT} from '../Teams';
+import Teams from '../Teams';
 import {useFetchTeams} from '../../data/useFetchTeams';
 import Header from '../../components/Header';
 import List from '../../components/List';
+import {mapTeamsToListItems} from '../../utils/teamUtils';
 
 jest.mock('../../data/useFetchTeams');
 jest.mock('../../components/Header');
@@ -24,54 +25,61 @@ const teamsData = [
 ];
 
 describe('Teams', () => {
-    beforeEach(() => {
-        (useFetchTeams as jest.Mock).mockReturnValue({
-            data: teamsData,
-            isLoading: false,
-        });
-    });
-
-    it('renders header with title', () => {
-        render(<Teams />);
-
-        expect(HeaderMock).toHaveBeenCalledTimes(1);
-        expect(HeaderMock).toHaveBeenCalledWith(
-            expect.objectContaining({
-                title: 'Teams',
-                showBackButton: false,
-            }),
-            {}
-        );
-    });
-
-    it('renders teams list', () => {
-        render(<Teams />);
-
-        expect(ListMock).toHaveBeenCalledTimes(1);
-        expect(ListMock).toHaveBeenCalledWith(
-            expect.objectContaining({
-                items: MapT(teamsData),
+    describe('Header', () => {
+        it('renders header with title', () => {
+            (useFetchTeams as jest.Mock).mockReturnValue({
+                data: teamsData,
                 isLoading: false,
-            }),
-            {}
-        );
+            });
+
+            render(<Teams />);
+
+            expect(HeaderMock).toHaveBeenCalledTimes(1);
+            expect(HeaderMock).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    title: 'Teams',
+                    showBackButton: false,
+                }),
+                {}
+            );
+        });
     });
 
-    it('renders spinner while loading', () => {
-        (useFetchTeams as jest.Mock).mockReturnValue({
-            data: null,
-            isLoading: true,
+    describe('List', () => {
+        it('renders teams list', () => {
+            (useFetchTeams as jest.Mock).mockReturnValue({
+                data: teamsData,
+                isLoading: false,
+            });
+
+            render(<Teams />);
+
+            expect(ListMock).toHaveBeenCalledTimes(1);
+            expect(ListMock).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    items: mapTeamsToListItems(teamsData),
+                    isLoading: false,
+                }),
+                {}
+            );
         });
 
-        render(<Teams />);
-
-        expect(ListMock).toHaveBeenCalledTimes(1);
-        expect(ListMock).toHaveBeenCalledWith(
-            expect.objectContaining({
-                items: MapT(null),
+        it('renders spinner while loading', () => {
+            (useFetchTeams as jest.Mock).mockReturnValue({
+                data: null,
                 isLoading: true,
-            }),
-            {}
-        );
+            });
+
+            render(<Teams />);
+
+            expect(ListMock).toHaveBeenCalledTimes(1);
+            expect(ListMock).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    items: mapTeamsToListItems(null),
+                    isLoading: true,
+                }),
+                {}
+            );
+        });
     });
 });

--- a/src/utils/__tests__/testTeamUtils.ts
+++ b/src/utils/__tests__/testTeamUtils.ts
@@ -1,0 +1,46 @@
+import {Teams} from 'types';
+import {mapTeamsToListItems} from '../teamUtils';
+
+describe('teamUtils', () => {
+    describe('mapTeamsToListItems', () => {
+        it('should correctly map teams to list items', () => {
+            const teams: Teams[] = [
+                {
+                    id: '1',
+                    name: 'Team 1',
+                },
+                {
+                    id: '2',
+                    name: 'Team 2',
+                },
+            ];
+
+            const expectedResult = [
+                {
+                    id: '1',
+                    url: '/team/1',
+                    columns: [{key: 'Name', value: 'Team 1'}],
+                    navigationProps: {
+                        id: '1',
+                        name: 'Team 1',
+                    },
+                },
+                {
+                    id: '2',
+                    url: '/team/2',
+                    columns: [{key: 'Name', value: 'Team 2'}],
+                    navigationProps: {
+                        id: '2',
+                        name: 'Team 2',
+                    },
+                },
+            ];
+
+            expect(mapTeamsToListItems(teams)).toEqual(expectedResult);
+        });
+
+        it('should return an empty array if the teams array is empty', () => {
+            expect(mapTeamsToListItems([])).toEqual([]);
+        });
+    });
+});

--- a/src/utils/teamUtils.ts
+++ b/src/utils/teamUtils.ts
@@ -1,0 +1,18 @@
+import {ListItem, Teams as TeamsList} from 'types';
+
+export const mapTeamsToListItems = (teams: TeamsList[]): ListItem[] => {
+    return teams?.map(team => {
+        const columns = [
+            {
+                key: 'Name',
+                value: team.name,
+            },
+        ];
+        return {
+            id: team.id,
+            url: `/team/${team.id}`,
+            columns,
+            navigationProps: team,
+        };
+    });
+};


### PR DESCRIPTION
- extract `MapT` helper and rename it, in order to have better code organization and test the function
- organize page tests using describe blocks for better structure