### PR TITLE
Search teams

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,4 +1,4 @@
-import {Teams, TeamOverview, UserData} from 'types';
+import {Team, TeamOverview, UserData} from 'types';
 
 const getData = async (path = '') => {
     const url = `${process.env.REACT_APP_API_BASE_URL}/${path}`;
@@ -8,7 +8,7 @@ const getData = async (path = '') => {
     return json;
 };
 
-export const getTeams = (): Promise<Teams[]> => {
+export const getTeams = (): Promise<Team[]> => {
     return getData('teams');
 };
 

--- a/src/components/Card/__tests__/testCard.tsx
+++ b/src/components/Card/__tests__/testCard.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {fireEvent, render, screen} from '@testing-library/react';
-import {Teams} from 'types';
+import {Team} from 'types';
 import Card from '..';
 
 const mockUseNavigate = jest.fn();
@@ -38,7 +38,7 @@ describe('Card', () => {
     });
 
     it('should navigate when card is clicked and navigation is enabled', () => {
-        const navProps: Teams = {
+        const navProps: Team = {
             id: '1',
             name: 'Team 1',
         };

--- a/src/components/Card/index.tsx
+++ b/src/components/Card/index.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import {useNavigate} from 'react-router-dom';
-import {Teams, UserData} from 'types';
+import {Team, UserData} from 'types';
 import {Container} from './styles';
 
 interface Props {
@@ -11,7 +11,7 @@ interface Props {
         value: string;
     }>;
     hasNavigation?: boolean;
-    navigationProps?: UserData | Teams;
+    navigationProps?: UserData | Team;
 }
 
 const Card = ({

--- a/src/components/Input/index.tsx
+++ b/src/components/Input/index.tsx
@@ -1,0 +1,8 @@
+import * as React from 'react';
+import {InputStyled} from './styles';
+
+const Input = (props: React.ComponentProps<typeof InputStyled>) => {
+    return <InputStyled {...props} />;
+};
+
+export default Input;

--- a/src/components/Input/styles.ts
+++ b/src/components/Input/styles.ts
@@ -1,0 +1,24 @@
+import styled from 'styled-components';
+
+export const InputStyled = styled.input`
+    display: block;
+    border: 1px solid black;
+    background: #fff;
+    padding: 8px 12px;
+    width: 100%;
+    max-width: 250px;
+    font-size: 16px;
+    color: #333;
+    border-radius: 4px;
+    outline: none;
+    transition: border-color 0.2s ease-in-out, box-shadow 0.2s ease-in-out;
+
+    &:focus {
+        border-color: #007bff;
+        box-shadow: 0 0 0 0.2rem rgba(0, 123, 255, 0.25);
+    }
+
+    &::placeholder {
+        color: #999;
+    }
+`;

--- a/src/data/useFetchTeams.tsx
+++ b/src/data/useFetchTeams.tsx
@@ -1,16 +1,16 @@
 import {useReducer, useEffect, useRef} from 'react';
-import {Teams as TeamsList} from 'types';
+import {Team} from 'types';
 import {getTeams} from 'api';
 
 type State = {
-    data: TeamsList[] | null;
+    data: Team[] | null;
     isLoading: boolean;
     error: string | null;
 };
 
 type Action =
     | {type: 'FETCH_INIT'}
-    | {type: 'FETCH_SUCCESS'; payload: TeamsList[]}
+    | {type: 'FETCH_SUCCESS'; payload: Team[]}
     | {type: 'FETCH_FAILURE'; payload: string};
 
 const dataFetchReducer = (state: State, action: Action): State => {

--- a/src/hooks/__tests__/testUseDebounce.ts
+++ b/src/hooks/__tests__/testUseDebounce.ts
@@ -1,0 +1,49 @@
+import {renderHook, act} from '@testing-library/react';
+import {useDebounce} from '../useDebounce';
+
+describe('useDebounce', () => {
+    beforeEach(() => {
+        jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+        jest.useRealTimers();
+    });
+
+    it('should return the initial value', () => {
+        const {result} = renderHook(() => useDebounce({value: 'initial value', delay: 300}));
+        expect(result.current).toBe('initial value');
+    });
+
+    it('should update the debounced value after the specified delay', () => {
+        const {result, rerender} = renderHook(({value, delay}) => useDebounce({value, delay}), {
+            initialProps: {value: 'initial value', delay: 300},
+        });
+
+        rerender({value: 'updated value', delay: 300});
+
+        expect(result.current).toBe('initial value');
+
+        act(() => {
+            jest.advanceTimersByTime(300);
+        });
+
+        expect(result.current).toBe('updated value');
+    });
+
+    it('should not update the debounced value if the delay has not passed', () => {
+        const {result, rerender} = renderHook(({value, delay}) => useDebounce({value, delay}), {
+            initialProps: {value: 'initial value', delay: 300},
+        });
+
+        rerender({value: 'updated value', delay: 300});
+
+        expect(result.current).toBe('initial value');
+
+        act(() => {
+            jest.advanceTimersByTime(200);
+        });
+
+        expect(result.current).toBe('initial value');
+    });
+});

--- a/src/hooks/__tests__/testUseTypeahead.ts
+++ b/src/hooks/__tests__/testUseTypeahead.ts
@@ -1,0 +1,17 @@
+import {renderHook, act} from '@testing-library/react';
+import {useTypeahead} from '../useTypeahead';
+
+describe('useTypeahead', () => {
+    it('should update search value on input change', () => {
+        const {result} = renderHook(() => useTypeahead());
+        expect(result.current.searchValue).toBe('');
+
+        act(() => {
+            result.current.handleSearchChange({
+                target: {value: 'test'},
+            } as React.ChangeEvent<HTMLInputElement>);
+        });
+
+        expect(result.current.searchValue).toBe('test');
+    });
+});

--- a/src/hooks/useDebounce.ts
+++ b/src/hooks/useDebounce.ts
@@ -1,0 +1,22 @@
+import {useEffect, useState} from 'react';
+
+interface Props {
+    value: string;
+    delay: number;
+}
+
+export const useDebounce = ({value, delay}: Props) => {
+    const [debouncedValue, setDebouncedValue] = useState(value);
+
+    useEffect(() => {
+        const handler = setTimeout(() => {
+            setDebouncedValue(value);
+        }, delay);
+
+        return () => {
+            clearTimeout(handler);
+        };
+    }, [value, delay]);
+
+    return debouncedValue;
+};

--- a/src/hooks/useTypeahead.ts
+++ b/src/hooks/useTypeahead.ts
@@ -1,0 +1,16 @@
+import {useState} from 'react';
+
+interface UseTypeahead {
+    searchValue: string;
+    handleSearchChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+}
+
+export const useTypeahead = (): UseTypeahead => {
+    const [searchValue, setSearchValue] = useState('');
+
+    const handleSearchChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+        setSearchValue(e.target.value);
+    };
+
+    return {searchValue, handleSearchChange};
+};

--- a/src/pages/Teams.tsx
+++ b/src/pages/Teams.tsx
@@ -1,17 +1,40 @@
 import * as React from 'react';
-import {mapTeamsToListItems} from '../utils/teamUtils';
-import {useFetchTeams} from '../data/useFetchTeams';
-import Header from '../components/Header';
-import List from '../components/List';
-import {Container} from '../components/GlobalComponents';
+import {mapTeamsToListItems} from 'utils/teamUtils';
+import {useFetchTeams} from 'data/useFetchTeams';
+import Header from 'components/Header';
+import List from 'components/List';
+import {Container} from 'components/GlobalComponents';
+import Input from 'components/Input';
+import {useTypeahead} from 'hooks/useTypeahead';
+import {useDebounce} from 'hooks/useDebounce';
+import {Team} from 'types';
+
+export const filteredTeams = (data: Team[], debouncedSearchValue: string) => {
+    return data?.filter(team =>
+        team.name.toLowerCase().includes(debouncedSearchValue.toLowerCase())
+    );
+};
 
 const Teams = () => {
     const {data, isLoading} = useFetchTeams();
+    const {searchValue, handleSearchChange} = useTypeahead();
+    const debouncedSearchValue = useDebounce({value: searchValue, delay: 300});
 
     return (
         <Container>
             <Header title="Teams" showBackButton={false} />
-            <List items={mapTeamsToListItems(data)} isLoading={isLoading} />
+            {!isLoading && (
+                <Input
+                    type="text"
+                    value={searchValue}
+                    onChange={handleSearchChange}
+                    placeholder="Search teams..."
+                />
+            )}
+            <List
+                items={mapTeamsToListItems(filteredTeams(data, debouncedSearchValue))}
+                isLoading={isLoading}
+            />
         </Container>
     );
 };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,4 +1,4 @@
-export interface Teams {
+export interface Team {
     id: string;
     name: string;
 }
@@ -27,5 +27,5 @@ export interface ListItem {
     id: string;
     url?: string;
     columns: Array<ListItemColumn>;
-    navigationProps?: UserData | Teams;
+    navigationProps?: UserData | Team;
 }

--- a/src/utils/__tests__/testTeamUtils.ts
+++ b/src/utils/__tests__/testTeamUtils.ts
@@ -1,10 +1,10 @@
-import {Teams} from 'types';
+import {Team} from 'types';
 import {mapTeamsToListItems} from '../teamUtils';
 
 describe('teamUtils', () => {
     describe('mapTeamsToListItems', () => {
         it('should correctly map teams to list items', () => {
-            const teams: Teams[] = [
+            const teams: Team[] = [
                 {
                     id: '1',
                     name: 'Team 1',

--- a/src/utils/teamUtils.ts
+++ b/src/utils/teamUtils.ts
@@ -1,6 +1,6 @@
-import {ListItem, Teams as TeamsList} from 'types';
+import {ListItem, Team} from 'types';
 
-export const mapTeamsToListItems = (teams: TeamsList[]): ListItem[] => {
+export const mapTeamsToListItems = (teams: Team[]): ListItem[] => {
     return teams?.map(team => {
         const columns = [
             {


### PR DESCRIPTION
- rename `Teams` interface to `Team`, this interface represent a single team, so it's more appropriate the name in the singular
- create a typeahead search hook, so the user can have a more fluid experience when search
- create a debounce hook, to have a better performance when using the typeahead functionality, UI won't re-render after every keypress